### PR TITLE
Pull request to allow support for newer rest client gem.

### DIFF
--- a/ruby_cleverbot.gemspec
+++ b/ruby_cleverbot.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.10"
 
-  spec.add_dependency "rest-client", ">= 1.6," "< 3.0"
+  spec.add_dependency "rest-client", ">= 1.6", "< 3.0"
 
   spec.required_ruby_version = '>= 1.9.3'
 end

--- a/ruby_cleverbot.gemspec
+++ b/ruby_cleverbot.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.10"
 
-  spec.add_dependency "rest-client", "~> 1.6"
+  spec.add_dependency "rest-client", ">= 1.6," "< 3.0"
 
   spec.required_ruby_version = '>= 1.9.3'
 end


### PR DESCRIPTION
I updated the gemspec to allow rest-client 1.6+ as long as it is less than 3.0

I built the gem from my gemspec and tried it out, and cleverbot appears to be working fine with it.
